### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Read and convert subtitle (`.srt`) file to `csv` or `List`
 
 ## build.sbt
 ```scala
-libraryDependencies += "io.github.mdauthentic" % "sous-title_2.13" % "0.3.0"
+libraryDependencies += "io.github.mdauthentic" %% "sous-title" % "0.3.0"
 ```
 
 ## Getting started


### PR DESCRIPTION
`%%` will append the Scala version

If you use `%` and _2.13 but you have a Scala version of 2.12.x it will crash at runtime with a weird classpath error.